### PR TITLE
Add evaluation metrics and confusion matrix to notebook

### DIFF
--- a/TP1_BITAR.ipynb
+++ b/TP1_BITAR.ipynb
@@ -276,7 +276,8 @@
     "from sklearn.preprocessing import StandardScaler\n",
     "from sklearn.decomposition import PCA\n",
     "from sklearn.ensemble import RandomForestClassifier\n",
-    "from sklearn.pipeline import make_pipeline"
+    "from sklearn.pipeline import make_pipeline\n",
+    "from sklearn.metrics import classification_report, confusion_matrix, accuracy_score\n"
    ]
   },
   {
@@ -342,6 +343,35 @@
     "print(f'Test accuracy: {test_acc:.3f}')\n",
     "diff = (y_test == y_pred)\n",
     "diff\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Évaluation du modèle\n",
+    "print(f\"Accuracy: {accuracy_score(y_test, y_pred):.3f}\")\n",
+    "print(\"Classification report:\n\", classification_report(y_test, y_pred, target_names=label_quality.classes_))\n",
+    "cm = confusion_matrix(y_test, y_pred)\n",
+    "plt.figure(figsize=(5,4))\n",
+    "sns.heatmap(cm, annot=True, fmt='d', cmap='Blues',\n",
+    "            xticklabels=label_quality.classes_,\n",
+    "            yticklabels=label_quality.classes_)\n",
+    "plt.xlabel('Prédit')\n",
+    "plt.ylabel('Réel')\n",
+    "plt.title('Matrice de confusion')\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Les valeurs de précision, rappel et F1-score fournies par le rapport de classification permettent d'évaluer la qualité du modèle.\n",
+    "La matrice de confusion illustre les prédictions correctes (diagonale) et les erreurs entre les classes 'bad' et 'good'.\n",
+    "Une concentration des valeurs sur la diagonale principale indique une bonne performance, tandis que des valeurs hors diagonale révèlent les types d'erreurs restantes."
    ]
   },
   {


### PR DESCRIPTION
## Summary
- import classification metrics utilities from scikit-learn
- compute accuracy, precision/recall/F1 report and show confusion matrix with heatmap
- add explanatory notes for interpreting evaluation results

## Testing
- ❌ `python - <<'PY'
import pandas as pd
PY` (ModuleNotFoundError: No module named 'pandas')
- ❌ `python - <<'PY'
import sklearn
PY` (ModuleNotFoundError: No module named 'sklearn')

------
https://chatgpt.com/codex/tasks/task_e_68c667417ad083229cd275ab87cab5e4