### PR TITLE
Fix evaluation to handle missing classes

### DIFF
--- a/TP1_BITAR.ipynb
+++ b/TP1_BITAR.ipynb
@@ -352,9 +352,10 @@
    "outputs": [],
    "source": [
     "# Évaluation du modèle\n",
+    "labels = label_quality.transform(label_quality.classes_)\n",
     "print(f\"Accuracy: {accuracy_score(y_test, y_pred):.3f}\")\n",
-    "print(\"Classification report:\n\", classification_report(y_test, y_pred, target_names=label_quality.classes_))\n",
-    "cm = confusion_matrix(y_test, y_pred)\n",
+    "print(\"Classification report:\n\", classification_report(y_test, y_pred, labels=labels, target_names=label_quality.classes_))\n",
+    "cm = confusion_matrix(y_test, y_pred, labels=labels)\n",
     "plt.figure(figsize=(5,4))\n",
     "sns.heatmap(cm, annot=True, fmt='d', cmap='Blues',\n",
     "            xticklabels=label_quality.classes_,\n",


### PR DESCRIPTION
## Summary
- Ensure evaluation reports include both encoded classes
- Use explicit labels for classification report and confusion matrix

## Testing
- ⚠️ `python MachineLearning_Training/grid_search_random_forest.py` *(missing pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68c661c3c5348322aca90b40e8feef2e